### PR TITLE
Update capacities

### DIFF
--- a/packages/cdk/lib/__snapshots__/basic-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/basic-asg-rolling-update.test.ts.snap
@@ -105,12 +105,12 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
           "MinSuccessfulInstancesPercent": 100,
         },
         "ResourceSignal": {
-          "Count": 5,
+          "Count": 3,
           "Timeout": "PT5M",
         },
       },
       "Properties": {
-        "DesiredCapacity": "5",
+        "DesiredCapacity": "3",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
@@ -124,13 +124,13 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
             ],
           },
         },
-        "MaxSize": "10",
+        "MaxSize": "6",
         "MetricsCollection": [
           {
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "5",
+        "MinSize": "3",
         "Tags": [
           {
             "Key": "App",
@@ -182,8 +182,8 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MaxBatchSize": 10,
-          "MinInstancesInService": 5,
+          "MaxBatchSize": 6,
+          "MinInstancesInService": 3,
           "MinSuccessfulInstancesPercent": 100,
           "SuspendProcesses": [],
           "WaitOnResourceSignals": true,

--- a/packages/cdk/lib/__snapshots__/no-desired-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/no-desired-asg-rolling-update.test.ts.snap
@@ -105,7 +105,7 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
           "MinSuccessfulInstancesPercent": 100,
         },
         "ResourceSignal": {
-          "Count": 5,
+          "Count": 3,
           "Timeout": "PT5M",
         },
       },
@@ -123,13 +123,13 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
             ],
           },
         },
-        "MaxSize": "10",
+        "MaxSize": "6",
         "MetricsCollection": [
           {
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "5",
+        "MinSize": "3",
         "Tags": [
           {
             "Key": "App",
@@ -181,8 +181,8 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MaxBatchSize": 10,
-          "MinInstancesInService": 5,
+          "MaxBatchSize": 6,
+          "MinInstancesInService": 3,
           "MinSuccessfulInstancesPercent": 100,
           "SuspendProcesses": [],
           "WaitOnResourceSignals": true,

--- a/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
@@ -105,12 +105,12 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
           "MinSuccessfulInstancesPercent": 100,
         },
         "ResourceSignal": {
-          "Count": 5,
+          "Count": 3,
           "Timeout": "PT5M",
         },
       },
       "Properties": {
-        "DesiredCapacity": "5",
+        "DesiredCapacity": "3",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
@@ -124,13 +124,13 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
             ],
           },
         },
-        "MaxSize": "10",
+        "MaxSize": "9",
         "MetricsCollection": [
           {
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "5",
+        "MinSize": "3",
         "Tags": [
           {
             "Key": "App",
@@ -182,8 +182,8 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MaxBatchSize": 10,
-          "MinInstancesInService": 5,
+          "MaxBatchSize": 9,
+          "MinInstancesInService": 3,
           "MinSuccessfulInstancesPercent": 100,
           "SuspendProcesses": [],
           "WaitOnResourceSignals": true,

--- a/packages/cdk/lib/basic-asg-rolling-update.ts
+++ b/packages/cdk/lib/basic-asg-rolling-update.ts
@@ -43,7 +43,7 @@ export class BasicAsgRollingUpdate extends GuStack {
 			},
 			monitoringConfiguration: { noMonitoring: true },
 			scaling: {
-				minimumInstances: 5,
+				minimumInstances: 3,
 			},
 			applicationLogging: {
 				enabled: true,

--- a/packages/cdk/lib/no-desired-asg-rolling-update.ts
+++ b/packages/cdk/lib/no-desired-asg-rolling-update.ts
@@ -44,7 +44,7 @@ export class NoDesiredAsgRollingUpdate extends GuStack {
 			},
 			monitoringConfiguration: { noMonitoring: true },
 			scaling: {
-				minimumInstances: 5,
+				minimumInstances: 3,
 			},
 			applicationLogging: {
 				enabled: true,

--- a/packages/cdk/lib/scaling-asg-rolling-update.ts
+++ b/packages/cdk/lib/scaling-asg-rolling-update.ts
@@ -43,7 +43,8 @@ export class ScalingAsgRollingUpdate extends GuStack {
 			},
 			monitoringConfiguration: { noMonitoring: true },
 			scaling: {
-				minimumInstances: 5,
+				minimumInstances: 3,
+				maximumInstances: 9,
 			},
 			applicationLogging: {
 				enabled: true,


### PR DESCRIPTION
`playground-CODE-basic-asg-rolling-update` and `playground-CODE-no-desired-asg-rolling-update` now use `Minimum=3` and `Maximum=6`; this is more representative of a typical simple Guardian app which runs a single instance in each Availability Zone. It will also be a bit cheaper than running 5 instances per test app.

`playground-CODE-scaling-asg-rolling-update` now uses `Minimum=3` and `Maximum=9`. This ensures that we have enough headroom to test scenarios where we are partially scaled up before a deployment starts.