### PR TITLE
Do not set desired capacity on the scaling-asg-rolling-update stack

### DIFF
--- a/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
@@ -110,7 +110,6 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
         },
       },
       "Properties": {
-        "DesiredCapacity": "3",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {

--- a/packages/cdk/lib/scaling-asg-rolling-update.ts
+++ b/packages/cdk/lib/scaling-asg-rolling-update.ts
@@ -4,6 +4,7 @@ import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
+import type { CfnAutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
 interface ScalingAsgRollingUpdateProps {
@@ -63,6 +64,9 @@ export class ScalingAsgRollingUpdate extends GuStack {
 		autoScalingGroup.scaleOnRequestCount('ScaleOnRequest', {
 			targetRequestsPerMinute: 5,
 		});
+
+		const cfnAsg = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+		cfnAsg.desiredCapacity = undefined;
 
 		new GuCname(this, 'DNS', {
 			app,


### PR DESCRIPTION
If a stack has scaling policies then setting the desired capacity in the template is unsafe.

See [this conclusion](https://docs.google.com/document/d/1nWPDD4R4TzqIUe8iX5-oZfiV_bz3V5-JWX2p47AqamM/edit#heading=h.qy05gwdbqg5i) and [this warning](https://github.com/guardian/riff-raff/blob/3360d4a152fd19c172637f559b105de34e61666d/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala#L35-L39) in the Riff-Raff docs.

For example, if the ASG has scaled up to 9 instances due to high traffic, we know that it will be scaled down to 3 instances after the current version of the template is applied. Consequently I think we need the desired capacity to be unset when running tests with this stack.

