### PR TITLE
Use simple scaling for easier testing

### DIFF
--- a/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
@@ -29,12 +29,33 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
+    "AutoscalingGroupName": {
+      "Value": {
+        "Ref": "AutoScalingGroupScalingASG8AF02C37",
+      },
+    },
     "LoadBalancerScalingDnsName": {
       "Description": "DNS entry for LoadBalancerScaling",
       "Value": {
         "Fn::GetAtt": [
           "LoadBalancerScaling238A9D29",
           "DNSName",
+        ],
+      },
+    },
+    "ScaleInArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "ScaleIn",
+          "Arn",
+        ],
+      },
+    },
+    "ScaleOutArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "ScaleOut",
+          "Arn",
         ],
       },
     },
@@ -191,79 +212,6 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
           "IgnoreUnmodifiedGroupSizeProperties": true,
         },
       },
-    },
-    "AutoScalingGroupScalingScalingPolicyScaleOnRequest26CCAA7B": {
-      "DependsOn": [
-        "ListenerScaling76B5CBA7",
-      ],
-      "Properties": {
-        "AutoScalingGroupName": {
-          "Ref": "AutoScalingGroupScalingASG8AF02C37",
-        },
-        "PolicyType": "TargetTrackingScaling",
-        "TargetTrackingConfiguration": {
-          "PredefinedMetricSpecification": {
-            "PredefinedMetricType": "ALBRequestCountPerTarget",
-            "ResourceLabel": {
-              "Fn::Join": [
-                "",
-                [
-                  {
-                    "Fn::Select": [
-                      1,
-                      {
-                        "Fn::Split": [
-                          "/",
-                          {
-                            "Ref": "ListenerScaling76B5CBA7",
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  "/",
-                  {
-                    "Fn::Select": [
-                      2,
-                      {
-                        "Fn::Split": [
-                          "/",
-                          {
-                            "Ref": "ListenerScaling76B5CBA7",
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  "/",
-                  {
-                    "Fn::Select": [
-                      3,
-                      {
-                        "Fn::Split": [
-                          "/",
-                          {
-                            "Ref": "ListenerScaling76B5CBA7",
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  "/",
-                  {
-                    "Fn::GetAtt": [
-                      "TargetGroupScalingFC90421F",
-                      "TargetGroupFullName",
-                    ],
-                  },
-                ],
-              ],
-            },
-          },
-          "TargetValue": 5,
-        },
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "CertificateScaling767DD870": {
       "DeletionPolicy": "Retain",
@@ -726,6 +674,28 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ScaleIn": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupScalingASG8AF02C37",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": -1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "ScaleOut": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupScalingASG8AF02C37",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": 1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "SsmSshPolicy4CFC977E": {
       "Properties": {

--- a/script/scale-in
+++ b/script/scale-in
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLOUDFORMATION_STACK_NAME=playground-CODE-scaling-asg-rolling-update
+
+POLICY_ARN=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleInArn") ] | any) | .OutputValue'
+)
+
+ASG_NAME=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
+)
+
+CURRENT_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+aws autoscaling execute-policy \
+  --policy-name "$POLICY_ARN" \
+  --profile developerPlayground \
+  --region eu-west-1
+
+NEW_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+echo "Desired capacity has been updated from $CURRENT_DESIRED_CAPACITY to $NEW_DESIRED_CAPACITY"

--- a/script/scale-out
+++ b/script/scale-out
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLOUDFORMATION_STACK_NAME=playground-CODE-scaling-asg-rolling-update
+
+POLICY_ARN=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleOutArn") ] | any) | .OutputValue'
+)
+
+ASG_NAME=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
+)
+
+CURRENT_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+aws autoscaling execute-policy \
+  --policy-name "$POLICY_ARN" \
+  --profile developerPlayground \
+  --region eu-west-1
+
+NEW_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+echo "Desired capacity has been updated from $CURRENT_DESIRED_CAPACITY to $NEW_DESIRED_CAPACITY"


### PR DESCRIPTION
## What does this change?
Switches the scaling behaviour from target tracking to simple scaling. This allows us to use the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/execute-policy.html) to programatically trigger a scale in/out event.

Target tracking scaling can be a little finicky to test. For example, testing behaviour of a rolling update policy where scale out happens mid-deployment requires us to time things correctly, and involves a bit of guess work.

Using simple scaling, we can start a deployment, then run `./script/scale-out`, which is simpler.

## Example usage

```console
❯ ./script/scale-out
Desired capacity has been updated from 3 to 4

❯ ./script/scale-in 
Desired capacity has been updated from 4 to 3
```