### PR TITLE
Add observations for second attempt at partially/fully scaled tests

### DIFF
--- a/observations/healthy-to-healthy-fully-scaled-v2.md
+++ b/observations/healthy-to-healthy-fully-scaled-v2.md
@@ -1,0 +1,98 @@
+# What happens when deploying a 'good' build when the service is already fully scaled up?
+
+In this test we went from [application version](../dist) `ABC` to `XYZ` in the stack:
+- [`ScalingAsgRollingUpdate`](../packages/cdk/lib/scaling-asg-rolling-update.ts) (CFN stack `playground-CODE-scaling-asg-rolling-update`).
+
+In response to a [previous version of this test](healthy-to-healthy-fully-scaled.md), we also injected the current
+desired capacity (minus 1) as the value for the
+[`MinInstancesInService`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice)
+property before starting the rolling update.
+
+The main aim of this test was to establish whether setting `MinInstancesInService` dynamically would allow us to avoid
+the undesirable mid-deployment under-provisioning that we noticed when this value was hardcoded.
+
+## Highlights
+
+Setting the `MinInstancesInService` property dynamically allows us to deploy slowly, whilst managing the
+risk of mid-deployment performance problems by removing one instance at a time.
+
+## Timeline
+
+1. [Build number 116 was deployed](https://riffraff.gutools.co.uk/deployment/view/587f6951-396d-4e11-8f6e-ead7e628383f)
+   to start from a known state, running artifact `ABC`
+
+   The ASG starts with a capacity of:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 3     |
+   | Max      | 9     |
+
+2. The service was manually scaled up by invoking our `scale-out` script 6 times.
+
+   The ASG capacities are now:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 9     |
+   | Max      | 9     |
+
+    There are 9 instances capable of serving requests (all running `ABC`).
+
+3. [Build number 120 was deployed](https://riffraff.gutools.co.uk/deployment/view/79dc6014-9f52-4dc9-9abb-32623cec3cf0).
+   This updates to use artifact `XYZ` _and_ [sets `MinInstancesInService` to 8](https://github.com/guardian/testing-asg-rolling-update/compare/main...jw-min-8-xyz).
+
+   _Note that this must be set to 8 (desired minus 1) and not 9 (desired) for the rolling update properties to be
+   accepted by CloudFormation._
+
+4. The CFN stack `playground-CODE-scaling-asg-rolling-update` begins to update the ASG. Due to the dynamically set
+`MinInstancesInService` property, AWS now avoids under-provisioning the service during the deployment:
+
+   > Rolling update initiated. Terminating 9 obsolete instance(s) in batches of 1, while keeping at least 8 instance(s) in service.
+
+   Note that, unlike in other scenarios, the ASG capacities are never modified:
+    
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 3     |
+    | Desired  | 9     |
+    | Max      | 9     |
+
+5. 1 instance is terminated and 1 new one is launched.
+
+   >  Terminating instance(s) [i-05c73f48e5bf41823]; replacing with 1 new instance(s).
+
+   There are 8 instances capable of serving requests (all running `ABC`).
+
+6. AWS receives a `SUCCESS` signal from the instance launched in the previous step:
+
+    > Successfully terminated instance(s) [i-05c73f48e5bf41823] (Progress 11%).
+    > Received SUCCESS signal with UniqueId i-08195865aff4a373c
+
+   There are (briefly) 9 instances capable of serving requests (8 running `ABC` and 1 running `XYZ`).
+
+7. AWS repeats this process for the remaining instances running `ABC`.
+
+   The ASG capacities are not modified.
+
+   We always have (at least) 8 instances capable of serving requests.
+
+8. Eventually AWS receives the `SUCCESS` signal from the final instance launched with `XYZ` and the deployment
+completes.
+
+    The ASG capacities are still unmodified.
+
+    We now have 9 instances capable of serving requests (all running `XYZ`).
+
+In this case the deployment took ~17 minutes. This would be even longer if: 
+
+a) There were more instances running at the start of the deployment (e.g. if `Max` and `Desired` were both 18).
+
+b) The application was slower to start (e.g. if it had a more complex userdata script or healthcheck).
+
+Full details can be seen via [the dashboard](https://metrics.gutools.co.uk/goto/BoGywk6SR?orgId=1).
+
+
+    

--- a/observations/healthy-to-healthy-partially-scaled-v2.md
+++ b/observations/healthy-to-healthy-partially-scaled-v2.md
@@ -1,0 +1,109 @@
+# What happens when deploying a 'good' build when the service is already partially scaled up?
+
+In this test we went from [application version](../dist) `ABC` to `XYZ` in the stack:
+- [`ScalingAsgRollingUpdate`](../packages/cdk/lib/scaling-asg-rolling-update.ts) (CFN stack `playground-CODE-scaling-asg-rolling-update`).
+
+In response to a [previous version of this test](healthy-to-healthy-partially-scaled.md), we also injected the current
+desired capacity as the value for the
+[`MinInstancesInService`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice)
+property before starting the rolling update.
+
+The main aim of this test was to establish whether setting `MinInstancesInService` dynamically would allow us to avoid
+the undesirable mid-deployment under-provisioning that we noticed when this value was hardcoded.
+
+## Highlights
+
+Setting the `MinInstancesInService` property dynamically allows us to deploy relatively quickly, without increasing the
+risk of mid-deployment performance problems.
+
+## Timeline
+
+1. [Build number 116 was deployed](https://riffraff.gutools.co.uk/deployment/view/cdaa893d-dec3-40e8-8252-5be72a441652)
+   to start from a known state, running artifact `ABC`
+
+    The ASG starts with a capacity of:
+    
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 3     |
+    | Desired  | 3     |
+    | Max      | 9     |
+
+2. The service was manually scaled up by invoking our `scale-out` script 3 times.
+
+    The ASG capacities are now:
+
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 3     |
+    | Desired  | 6     |
+    | Max      | 9     |
+
+   There are 6 instances capable of serving requests (all running `ABC`).
+
+3. [Build number 117 was deployed](https://riffraff.gutools.co.uk/deployment/view/a231e031-7187-4ec7-b64e-7afa2cbdb45e).
+   This updates to use artifact `XYZ` _and_ [sets `MinInstancesInService` to 6](https://github.com/guardian/testing-asg-rolling-update/compare/main...jw-min-6-xyz).
+
+4. The CFN stack `playground-CODE-scaling-asg-rolling-update` begins to update the ASG:
+
+   > Temporarily setting autoscaling group MinSize and DesiredCapacity to 9.
+
+   Consequently, the ASG now has a capacity of:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 9     |
+   | Desired  | 9     |
+   | Max      | 9     |
+
+   Due to the dynamically set `MinInstancesInService` property, AWS now avoids under-provisioning the service
+   during the deployment:
+   
+   > Rolling update initiated. Terminating 6 obsolete instance(s) in batches of 3, while keeping at least 6 instance(s) in service.
+
+5. Once three `SUCCESS` signals are received, 3 instances are terminated and 3 new ones are launched.
+
+   >  Terminating instance(s) [i-023fbdd4382a9dcd1,i-0005ea168f117bd60,i-08f8bf3b8d8dacdbb]; replacing with 3 new instance(s).
+
+    The ASG still has a capacity of:
+    
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 9     |
+    | Desired  | 9     |
+    | Max      | 9     |    
+
+   There are 6 instances capable of serving requests (3 running `XYZ` and 3 running `ABC`).
+
+6. The 3 new instances (launched in previous step) send a `SUCCESS` signal and start serving traffic.
+
+    The ASG still has a capacity of:
+
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 9     |
+    | Desired  | 9     |
+    | Max      | 9     |    
+
+    There are (briefly) 9 instances capable of serving requests (6 running `XYZ` and 3 running `ABC`).
+
+7. It is now safe for AWS to terminate the remaining instances running ABC, so it does so:
+
+    > Terminating instance(s) [i-0b455277568a554b5,i-0e92472e453425cb1,i-0dfe47c2a8e53b0b7]; replacing with 0 new instance(s).
+   
+    The update completes once these instances are terminated.
+ 
+8. The ASG capacities are updated, so we end with the capacities that we started with:
+
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 3     |
+    | Desired  | 6     |
+    | Max      | 9     |  
+
+    All 6 instances serving traffic are now running `XYZ`.
+
+Full details can be seen via [the dashboard](https://metrics.gutools.co.uk/goto/EhZPyzeSg?orgId=1).
+
+
+    

--- a/observations/healthy-to-unhealthy-fully-scaled-v2.md
+++ b/observations/healthy-to-unhealthy-fully-scaled-v2.md
@@ -1,0 +1,90 @@
+# What happens when deploying a 'bad' build when the service is already fully scaled up?
+
+In this test we went from [application version](../dist) `ABC` to `500` in the stack:
+- [`ScalingAsgRollingUpdate`](../packages/cdk/lib/scaling-asg-rolling-update.ts) (CFN stack `playground-CODE-scaling-asg-rolling-update`).
+
+In response to a [previous version of this test](healthy-to-healthy-fully-scaled.md), we also injected the current
+desired capacity (minus 1) as the value for the
+[`MinInstancesInService`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice)
+property before starting the rolling update.
+
+The main aim of this test was to establish whether the behaviour is acceptable when a broken build is deployed while
+a service is fully scaled up.
+
+## Highlights
+
+Generally the failure is handled gracefully and there should be minimal impact on end users; there will be 1 less
+instance capable of serving requests until the automated rollback is triggered.
+
+At the end of the deployment the service is left correctly provisioned.
+
+## Timeline
+
+1. [Build number 121 was deployed](https://riffraff.gutools.co.uk/deployment/view/62a632c9-3f9f-4c50-a1d5-6430af2eb03e)
+   to start from a known state, running artifact `ABC`
+
+   The ASG starts with a capacity of:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 3     |
+   | Max      | 9     |
+
+2. The service was manually scaled up by invoking our `scale-out` script 6 times.
+
+   The ASG capacities are now:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 9     |
+   | Max      | 9     |
+
+   There are 9 instances capable of serving requests (all running `ABC`).
+
+3. [Build number 127 was deployed](https://riffraff.gutools.co.uk/deployment/view/af9f4560-7ed0-46ea-96a3-17b42aaa87d9).
+   This updates to use artifact `500` _and_ [sets `MinInstancesInService` to 8](https://github.com/guardian/testing-asg-rolling-update/compare/main...jw-min-8-500).
+
+4. The CFN stack `playground-CODE-scaling-asg-rolling-update` begins to update the ASG. 
+
+    > Rolling update initiated. Terminating 9 obsolete instance(s) in batches of 1, while keeping at least 8 instance(s) in service.
+
+    Note that, unlike in other scenarios, the ASG capacities are never modified:
+
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 3     |
+    | Desired  | 9     |
+    | Max      | 9     |
+
+5. AWS waits exactly 5-minutes for the new instance to come into service (this will never happen because the healthcheck
+   is intentionally broken):
+
+    > Failed to receive 1 resource signal(s) for the current batch.  Each resource signal timeout is counted as a FAILURE. 
+    > Received 0 SUCCESS signal(s) out of 9.  Unable to satisfy 100% MinSuccessfulInstancesPercent requirement
+
+   During this 5-minute period there are 8 instances capable of serving requests (all running `ABC`). This is one fewer
+   than before the deployment started, so it may have an impact on performance.
+
+6. The rollback starts:
+
+   > Rolling update initiated. Terminating 1 obsolete instance(s) in batches of 1, while keeping at least 3 instance(s) in service.
+
+   And the instance running `500` is terminated and replaced with an instances running `ABC`:
+
+   > Terminating instance(s) [i-033173ed110ee20c6]; replacing with 1 new instance(s).
+
+7. Once the instance running `ABC` sends its `SUCCESS` signal, the rollback completes.
+
+   At the end of the deployment the ASG capacities are correct (i.e. the same as before the deployment started):
+
+    | Capacity | Value |
+    |----------|-------|
+    | Min      | 3     |
+    | Desired  | 9     |
+    | Max      | 9     |
+
+    There are now 9 instances capable of serving requests again (all running `ABC`).
+
+Full details can be seen via [the dashboard](https://metrics.gutools.co.uk/goto/mK9IGM6SR?orgId=1).

--- a/observations/healthy-to-unhealthy-partially-scaled-v2.md
+++ b/observations/healthy-to-unhealthy-partially-scaled-v2.md
@@ -1,0 +1,92 @@
+# What happens when deploying a 'bad' build when the service is already partially scaled up?
+
+In this test we went from [application version](../dist) `ABC` to `500` in the stack:
+- [`ScalingAsgRollingUpdate`](../packages/cdk/lib/scaling-asg-rolling-update.ts) (CFN stack `playground-CODE-scaling-asg-rolling-update`).
+
+In response to a [previous version of this test](healthy-to-healthy-partially-scaled.md), we also injected the current
+desired capacity as the value for the
+[`MinInstancesInService`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice)
+property before starting the rolling update.
+
+The main aim of this test was to establish whether the behaviour is acceptable when a broken build is deployed while
+a service is partially scaled up.
+
+## Highlights
+
+Generally the failure is handled gracefully and there should be no impact on end users.
+
+At the end of the deployment the service is left over-provisioned, but this is not problematic in this context as scale-in
+alarms should correct this over-provisioning automatically.
+
+## Timeline
+
+1. [Build number 121 was deployed](https://riffraff.gutools.co.uk/deployment/view/8cbb693b-3db5-48f8-a522-4f11c07c20e1)
+   to start from a known state, running artifact `ABC`
+
+   The ASG starts with a capacity of:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 3     |
+   | Max      | 9     |
+
+2. The service was manually scaled up by invoking our `scale-out` script 3 times.
+
+   The ASG capacities are now:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 6     |
+   | Max      | 9     |
+
+   There are 6 instances capable of serving requests (all running `ABC`).
+
+3. [Build number 126 was deployed](https://riffraff.gutools.co.uk/deployment/view/77ebbd39-8373-4658-9fd6-833518b9d8c9).
+   This updates to use artifact `500` _and_ [sets `MinInstancesInService` to 6](https://github.com/guardian/testing-asg-rolling-update/compare/main...jw-min-6-500).
+
+4. The CFN stack `playground-CODE-scaling-asg-rolling-update` begins to update the ASG:
+
+   > Temporarily setting autoscaling group MinSize and DesiredCapacity to 9.
+
+   Consequently, the ASG now has a capacity of:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 9     |
+   | Desired  | 9     |
+   | Max      | 9     |
+
+5. AWS waits exactly 5-minutes for the new instances to come into service (this will never happen because the healthcheck
+is intentionally broken):
+
+    > Failed to receive 3 resource signal(s) for the current batch.  Each resource signal timeout is counted as a FAILURE.
+    > Received 0 SUCCESS signal(s) out of 6.  Unable to satisfy 100% MinSuccessfulInstancesPercent requirement 
+
+   During this 5-minute period there are still 6 instances capable of serving requests (all running `ABC`).
+
+6. The rollback starts:
+
+    > Rolling update initiated. Terminating 3 obsolete instance(s) in batches of 3, while keeping at least 3 instance(s) in service.
+
+    And the 3 instances running `500` are terminated and replaced with instances running `ABC`:
+
+    > Terminating instance(s) [i-0db270257b1c04b13,i-056b7b3edcd415cf8,i-0f1eba98c21762963]; replacing with 3 new instance(s).
+
+7. Once the instances running `ABC` send their `SUCCESS` signals, the rollback completes.
+
+    At the end of the deployment the ASG capacities are as follows:
+
+   | Capacity | Value |
+   |----------|-------|
+   | Min      | 3     |
+   | Desired  | 9     |
+   | Max      | 9     |
+
+    There are now 9 instances capable of serving requests (all running `ABC`).
+
+    Strictly speaking, we only need 6 (`Desired` should be 6, as it was before the deployment started), but we can allow
+    the scale-in alarms to fix this for us.
+
+Full details can be seen via [the dashboard](https://metrics.gutools.co.uk/goto/801qgMeIg?orgId=1).


### PR DESCRIPTION
We tested a potential workaround for some issues noticed in https://github.com/guardian/testing-asg-rolling-update/pull/9 and https://github.com/guardian/testing-asg-rolling-update/pull/10.

This PR documents our findings.