### PR TITLE
Update to latest version of GuCDK branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9824,15 +9824,15 @@
       "version": "0.0.0",
       "devDependencies": {
         "@guardian/cdk": "github:guardian/cdk#aa/ec2-AutoScalingReplacingUpdate",
-        "aws-cdk": "2.153.0",
-        "aws-cdk-lib": "2.153.0",
+        "aws-cdk": "2.157.0",
+        "aws-cdk-lib": "2.157.0",
         "constructs": "10.3.0",
         "source-map-support": "0.5.21"
       }
     },
     "packages/cdk/node_modules/@guardian/cdk": {
       "version": "59.2.4",
-      "resolved": "git+ssh://git@github.com/guardian/cdk.git#00ef0467d7797629015f088f969e2bcdab472046",
+      "resolved": "git+ssh://git@github.com/guardian/cdk.git#b4801a052a6f662c20db124d097588a123333d40",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",

--- a/packages/cdk/lib/__snapshots__/basic-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/basic-asg-rolling-update.test.ts.snap
@@ -71,7 +71,7 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AsgReplacingUpdatePolicy78CF34D5": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -90,7 +90,7 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "AsgReplacingUpdatePolicy78CF34D5",
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
         "Roles": [
           {
             "Ref": "InstanceRoleBasicC6212E32",
@@ -185,11 +185,11 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
           "MaxBatchSize": 6,
           "MinInstancesInService": 3,
           "MinSuccessfulInstancesPercent": 100,
-          "SuspendProcesses": [],
+          "PauseTime": "PT5M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
           "WaitOnResourceSignals": true,
-        },
-        "AutoScalingScheduledAction": {
-          "IgnoreUnmodifiedGroupSizeProperties": true,
         },
       },
     },
@@ -828,6 +828,7 @@ exports[`The BasicAsgRollingUpdate stack matches the snapshot 1`] = `
           "InstanceType": "t4g.micro",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {
@@ -929,7 +930,8 @@ aws s3 cp 's3://",
 dpkg -i /basic/testing-asg-rolling-update_ABC.deb
 # GuEc2AppExperimental UserData Start
 
-      INSTANCE_ID=$(ec2metadata --instance-id)
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
 
       STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
                   {

--- a/packages/cdk/lib/__snapshots__/no-desired-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/no-desired-asg-rolling-update.test.ts.snap
@@ -71,7 +71,7 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AsgReplacingUpdatePolicy78CF34D5": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -90,7 +90,7 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "AsgReplacingUpdatePolicy78CF34D5",
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
         "Roles": [
           {
             "Ref": "InstanceRoleNodesired2CBB5C37",
@@ -184,11 +184,11 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
           "MaxBatchSize": 6,
           "MinInstancesInService": 3,
           "MinSuccessfulInstancesPercent": 100,
-          "SuspendProcesses": [],
+          "PauseTime": "PT5M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
           "WaitOnResourceSignals": true,
-        },
-        "AutoScalingScheduledAction": {
-          "IgnoreUnmodifiedGroupSizeProperties": true,
         },
       },
     },
@@ -827,6 +827,7 @@ exports[`The NoDesiredAsgRollingUpdate stack matches the snapshot 1`] = `
           "InstanceType": "t4g.micro",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {
@@ -928,7 +929,8 @@ aws s3 cp 's3://",
 dpkg -i /no-desired/testing-asg-rolling-update_ABC.deb
 # GuEc2AppExperimental UserData Start
 
-      INSTANCE_ID=$(ec2metadata --instance-id)
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
 
       STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
                   {

--- a/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/scaling-asg-rolling-update.test.ts.snap
@@ -46,7 +46,7 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
     "ScaleInArn": {
       "Value": {
         "Fn::GetAtt": [
-          "ScaleIn",
+          "AutoScalingGroupScalingScaleInA1C7C09B",
           "Arn",
         ],
       },
@@ -54,7 +54,7 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
     "ScaleOutArn": {
       "Value": {
         "Fn::GetAtt": [
-          "ScaleOut",
+          "AutoScalingGroupScalingScaleOut0D780FEC",
           "Arn",
         ],
       },
@@ -75,6 +75,11 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "MinInstancesInServiceForscaling": {
+      "Default": 3,
+      "MaxValue": 8,
+      "Type": "Number",
+    },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
@@ -92,7 +97,7 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AsgReplacingUpdatePolicy78CF34D5": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -111,7 +116,7 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "AsgReplacingUpdatePolicy78CF34D5",
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
         "Roles": [
           {
             "Ref": "InstanceRoleScaling7E871D7B",
@@ -203,15 +208,39 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": 9,
-          "MinInstancesInService": 3,
+          "MinInstancesInService": {
+            "Ref": "MinInstancesInServiceForscaling",
+          },
           "MinSuccessfulInstancesPercent": 100,
-          "SuspendProcesses": [],
+          "PauseTime": "PT5M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
           "WaitOnResourceSignals": true,
         },
-        "AutoScalingScheduledAction": {
-          "IgnoreUnmodifiedGroupSizeProperties": true,
-        },
       },
+    },
+    "AutoScalingGroupScalingScaleInA1C7C09B": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupScalingASG8AF02C37",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": -1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "AutoScalingGroupScalingScaleOut0D780FEC": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupScalingASG8AF02C37",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": 1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "CertificateScaling767DD870": {
       "DeletionPolicy": "Retain",
@@ -675,28 +704,6 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ScaleIn": {
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoScalingGroupScalingASG8AF02C37",
-        },
-        "PolicyType": "SimpleScaling",
-        "ScalingAdjustment": -1,
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-    },
-    "ScaleOut": {
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoScalingGroupScalingASG8AF02C37",
-        },
-        "PolicyType": "SimpleScaling",
-        "ScalingAdjustment": 1,
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-    },
     "SsmSshPolicy4CFC977E": {
       "Properties": {
         "PolicyDocument": {
@@ -870,6 +877,7 @@ exports[`The ScalingAsgRollingUpdate stack matches the snapshot 1`] = `
           "InstanceType": "t4g.micro",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {
@@ -971,7 +979,8 @@ aws s3 cp 's3://",
 dpkg -i /scaling/testing-asg-rolling-update_ABC.deb
 # GuEc2AppExperimental UserData Start
 
-      INSTANCE_ID=$(ec2metadata --instance-id)
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
 
       STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
                   {

--- a/packages/cdk/lib/scaling-asg-rolling-update.ts
+++ b/packages/cdk/lib/scaling-asg-rolling-update.ts
@@ -62,14 +62,14 @@ export class ScalingAsgRollingUpdate extends GuStack {
 			'testing-asg-rolling-update.service',
 		);
 
-		const scaleOutPolicy = new CfnScalingPolicy(this, 'ScaleOut', {
+		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
 			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
 			policyType: 'SimpleScaling',
 			adjustmentType: 'ChangeInCapacity',
 			scalingAdjustment: 1,
 		});
 
-		const scaleInPolicy = new CfnScalingPolicy(this, 'ScaleIn', {
+		const scaleInPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleIn', {
 			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
 			policyType: 'SimpleScaling',
 			adjustmentType: 'ChangeInCapacity',

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@guardian/cdk": "github:guardian/cdk#aa/ec2-AutoScalingReplacingUpdate",
-    "aws-cdk": "2.153.0",
-    "aws-cdk-lib": "2.153.0",
+    "aws-cdk": "2.157.0",
+    "aws-cdk-lib": "2.157.0",
     "constructs": "10.3.0",
     "source-map-support": "0.5.21"
   }


### PR DESCRIPTION
Testing the latest updates of https://github.com/guardian/cdk/pull/2417.

[It deploys as expected](https://riffraff.gutools.co.uk/deployment/view/631f2925-91c2-4457-ad03-0131781971b7).